### PR TITLE
remove: redundant space in arg list

### DIFF
--- a/model/riscv_types_kext.sail
+++ b/model/riscv_types_kext.sail
@@ -103,7 +103,7 @@ function xt3(x) = {
 
 /* Multiply 8-bit field element by 4-bit value for AES MixCols step */
 val gfmul : (bits(8), bits(4)) -> bits(8)
-function gfmul( x, y) = {
+function gfmul(x, y) = {
   (if bit_to_bool(y[0]) then             x    else 0x00) ^
   (if bit_to_bool(y[1]) then xt2(        x)   else 0x00) ^
   (if bit_to_bool(y[2]) then xt2(xt2(    x))  else 0x00) ^


### PR DESCRIPTION
I am not sure whether this space is necessary, but, if unnecessary, removing this may give a better appearance in the K ext spec.